### PR TITLE
📌 Pin `ot-fuzzer` to a commit hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "chai": "^4.2.0",
     "lodash": "^4.17.15",
     "mocha": "^6.1.4",
-    "ot-fuzzer": "^1.2.1"
+    "ot-fuzzer": "ottypes/fuzzer#6fd20fb176fa9ea0d59108a7cb6f96ad08869e23"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
This build is currently failing because of an upstream break in the
`ot-fuzzer` test library.

This has [already been patched][1], but not released, so this change
pins our version to the latest git commit hash.

[1]: https://github.com/ottypes/fuzzer/pull/5