### PR TITLE
⬆️ Unpin `ot-fuzzer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "chai": "^4.2.0",
     "lodash": "^4.17.15",
     "mocha": "^6.1.4",
-    "ot-fuzzer": "ottypes/fuzzer#6fd20fb176fa9ea0d59108a7cb6f96ad08869e23"
+    "ot-fuzzer": "^1.3.1"
   },
   "engines": {
     "node": ">=0.10"


### PR DESCRIPTION
The fix we needed has now [been released][1].

[1]: https://github.com/ottypes/fuzzer/pull/5#issuecomment-997054221