### PR TITLE
💥 Skip `undefined` serialized props and fix `apply()`

### DIFF
--- a/lib/delta-with-metadata.js
+++ b/lib/delta-with-metadata.js
@@ -14,7 +14,7 @@ var DeltaWithMetadata = function (obj) {
   if (!obj) return;
 
   for (var key in config.serializedProperties) {
-    if (config.serializedProperties[key]) this[key] = obj[key];
+    if (config.serializedProperties[key] && obj[key] !== undefined) this[key] = obj[key];
   }
 };
 

--- a/lib/type.js
+++ b/lib/type.js
@@ -14,17 +14,14 @@ module.exports = {
     },
 
     apply: function (snapshot, delta) {
-      const metadata = snapshot && snapshot.metadata;
-
-      snapshot = new Delta(snapshot);
       delta = new Delta(delta);
-      snapshot = snapshot.compose(delta);
+      var composed = new Delta(snapshot).compose(delta);
 
-      if (metadata) {
-        snapshot.metadata = metadata;
+      for (var key in config.serializedProperties) {
+        if (config.serializedProperties[key] && snapshot[key] !== undefined) composed[key] = snapshot[key];
       }
 
-      return snapshot;
+      return composed;
     },
 
     compose: function (delta1, delta2) {
@@ -58,7 +55,7 @@ module.exports = {
       var serialized = {ops: delta.ops};
 
       for (var key in config.serializedProperties) {
-        if (config.serializedProperties[key]) serialized[key] = delta[key];
+        if (config.serializedProperties[key] && delta[key] !== undefined) serialized[key] = delta[key];
       }
 
       return serialized;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/rich-text",
-  "version": "4.1.0-reedsy.3.1.0",
+  "version": "4.1.0-reedsy.4.0.0",
   "description": "OT type for rich text",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/ottypes/rich-text",


### PR DESCRIPTION
This **BREAKING** change removes `undefined` metadata values from their serialized/deserialized objects to reduce object noise.

We allowed configuration of extra fields similar to our existing `metadata` property in https://github.com/reedsy/rich-text/pull/16

However, this change missed that we also keep `metadata` when calling `apply()`.

This change reads the configured props across in `apply()` as well.