### PR TITLE
⬆️ Bump `@reedsy/quill-delta`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@reedsy/rich-text' {
-  import Delta from '@reedsy/quill-delta';
+  import {Delta} from '@reedsy/quill-delta';
   import * as sharedb from 'sharedb';
 
   export type Type = (typeof sharedb)['types']['map'][string];

--- a/lib/type.js
+++ b/lib/type.js
@@ -1,4 +1,4 @@
-var Delta = require('@reedsy/quill-delta');
+var Delta = require('@reedsy/quill-delta').Delta;
 var DeltaWithMetadata = require('./delta-with-metadata');
 const config = require('./config');
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@reedsy/rich-text",
-  "version": "4.1.0-reedsy.4.1.2",
+  "version": "4.1.0-reedsy.4.1.3",
   "description": "OT type for rich text",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/ottypes/rich-text",
   "main": "index.js",
   "dependencies": {
-    "@reedsy/quill-delta": "^5.1.0-reedsy.3.0.0",
+    "@reedsy/quill-delta": "^5.1.0-reedsy.4.0.0",
     "@types/sharedb": "^5.1.0"
   },
   "devDependencies": {

--- a/test/presence.js
+++ b/test/presence.js
@@ -1,4 +1,4 @@
-const Delta = require("@reedsy/quill-delta");
+const Delta = require("@reedsy/quill-delta").Delta;
 var richText = require('../lib/type').type;
 var expect = require('chai').expect;
 


### PR DESCRIPTION
This change bumps our version of `@reedsy/quill-delta` through a major bump that removes export defaults.